### PR TITLE
fix: build plugin, exclude dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,12 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-client-serialization:1.5.4")
+    implementation("io.ktor:ktor-client-serialization:1.5.4") {
+        exclude(group = "org.jetbrains.kotlin")
+        exclude(group = "org.jetbrains.kotlinx")
+        exclude(group = "org.slf4j")
+        exclude(group = "io.ktor", module = "ktor-client-core")
+    }
 }
 
 tasks {


### PR DESCRIPTION
减小编译得到的 `mirai.jar` 体积